### PR TITLE
프론트엔드 개발 서버에서 오는 요청 허용

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const corsOptions = {
     'http://localhost:3000',
     'https://local.yoriquiz.site',
     'https://yoriquiz.site',
+    'https://dev.yoriquiz.site',
   ],
   credentials: true,
 };


### PR DESCRIPTION
* 프론트엔드 개발 서버를 새로 개설함에 따라 해당 origin 을 CORS allowlist 에 추가합니다. 
