### PR TITLE
채팅 비교 로직 answer 가져오는 곳에서 잘못된 키값으로 가져오는 문제 해결

### DIFF
--- a/src/service/chat.service.js
+++ b/src/service/chat.service.js
@@ -64,7 +64,7 @@ const addChat = (req, res, next) => {
       chats.startIndex += diff;
       chats.data.splice(0, diff);
     }
-    const answer = currentGameData.currentRecipe.RCP_MM;
+    const answer = currentGameData.currentRecipe.RCP_NM;
     console.log(`answer: ${answer}, userInput: ${userInput}`);
     const isAnswerCorrect = answer.trim() === userInput.trim();
     if (isAnswerCorrect) {


### PR DESCRIPTION
* 채팅 비교 로직에서 `answer` 가져올 때 잘못된 키값으로 가져오고 있습니다. 이부분 수정합니다. 
* 그리고 `try-catch` 블럭이 너무 넓게 잡혀 있어서 지금처럼 채팅이 전송은 되는데... 401 Unauthorized 가 내려가는.. 경우가 있습니다. 개선의 여지가 있지 않을까 생각이 듭니다. 